### PR TITLE
Improve Redgifs proxy normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,11 +313,51 @@ const ui = {
 };
 
 /* -------------------- Redgifs Proxy Resolver -------------------- */
+function extractRedgifsId(input) {
+  if (!input) return null;
+  const str = String(input).trim();
+
+  // If an entire iframe HTML snippet was passed, pull out the src attribute first
+  const iframeSrc = str.includes('<iframe')
+    ? (str.match(/src=["']([^"']+redgifs[^"']*)["']/i)?.[1] || '')
+    : '';
+  const candidate = iframeSrc || str;
+
+  // Direct embeds such as https://redgifs.com/watch/{id}
+  const directMatch = candidate.match(/redgifs\.com\/(?:watch|ifr|detail)\/([a-zA-Z0-9_-]+)/i);
+  if (directMatch) return cleanRedgifsId(directMatch[1]);
+
+  // Thumbnails/CDN assets live on subdomains like thumbs2.redgifs.com or i.redgifs.com
+  try {
+    const url = new URL(candidate);
+    if (/redgifs\.com$/i.test(url.hostname) || /\.redgifs\.com$/i.test(url.hostname)) {
+      const parts = url.pathname.split('/').filter(Boolean);
+      const raw = parts.pop();
+      const cleaned = cleanRedgifsId(raw);
+      if (cleaned) return cleaned;
+    }
+  } catch (_) {
+    // Non-URL strings will be handled by the fallback below
+  }
+
+  const raw = candidate.split('?')[0].split('/').filter(Boolean).pop();
+  return cleanRedgifsId(raw);
+}
+
+function cleanRedgifsId(raw) {
+  if (!raw) return null;
+  return raw
+    .replace(/\.(?:mp4|gif|webm|jpe?g|png|webp)$/i, '')
+    .replace(/-(?:size_restricted|mobile|poster)$/i, '')
+    .replace(/_(?:mobile)$/i, '');
+}
+
 async function resolveViaProxy(redgifsUrl) {
-  // Extract ID from any Redgifs URL
-  const match = String(redgifsUrl).match(/([a-zA-Z0-9_-]+)$/);
-  if (!match) return null;
-  const id = match[1];
+  const id = extractRedgifsId(redgifsUrl);
+  if (!id) {
+    dbg('❌ Proxy error', 'Unable to parse Redgifs id from', redgifsUrl);
+    return null;
+  }
 
   try {
     // ✅ Use your deployed Vercel proxy (full URL)
@@ -695,6 +735,7 @@ async function normalize(d) {
 
   if (/redgifs\.com/i.test(redgifsUrl)) {
     const playable = await resolveViaProxy(redgifsUrl);
+    const redgifsId = extractRedgifsId(redgifsUrl);
     if (playable) {
       return {
         t: 'video',
@@ -703,7 +744,7 @@ async function normalize(d) {
         title: d.title,
         author: d.author,
         sub: d.subreddit,
-        link: `https://www.redgifs.com/watch/${(redgifsUrl.match(/([a-zA-Z0-9_-]+)$/) || [])[1]}`,
+        link: redgifsId ? `https://www.redgifs.com/watch/${redgifsId}` : d.url,
         provider: 'redgifs'
       };
     }


### PR DESCRIPTION
## Summary
- harden Redgifs id extraction to handle iframe embeds and CDN thumbnail URLs before proxying
- sanitize derived ids (extensions, mobile suffixes) and reuse them for canonical watch links

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f8547135a483258c9bfa8707d19c0c