### PR TITLE
Handle Drive share links in fallback video resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,10 +248,21 @@ const FALLBACK_SOURCE_INPUT = "1jiMLN5dM0KLGj_uDw41kvCrTt-Qbbzpp";
 
 function resolveFallbackUrl(input) {
   if (!input) return "";
+  input = input.trim();
+  if (!input) return "";
+
+  const driveShareMatch = input.match(/^https?:\/\/drive\.google\.com\/file\/d\/([^/]+)\/view(?:\?.*)?(?:#.*)?$/i);
+  if (driveShareMatch) {
+    const id = driveShareMatch[1];
+    const driveUrl = `https://drive.google.com/uc?export=download&id=${id}`;
+    dbg("🎬 Fallback source detected as Google Drive ID:", id, "→", driveUrl);
+    return driveUrl;
+  }
+
   // If it's clearly a URL already (http/https)
   if (/^https?:\/\//i.test(input)) {
     dbg("🎬 Fallback source detected as direct URL:", input);
-    return input.trim();
+    return input;
   }
   // Otherwise treat as Google Drive file ID
   const driveUrl = `https://drive.google.com/uc?export=download&id=${input}`;


### PR DESCRIPTION
## Summary
- trim fallback video inputs before processing to avoid misdetecting URLs
- convert Google Drive share links to direct download URLs while keeping existing dbg logging
- preserve direct URLs and Drive ID handling for the fallback video source

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f96855e8548325bde570422f41738b