### PR TITLE
Fix boot crash by defining waitForLocalVideoReady

### DIFF
--- a/index.html
+++ b/index.html
@@ -1367,6 +1367,10 @@ async function renderChunk(where, n=CHUNK){
   }finally{ loadLock=false; ui.progressVisibility(); }
 }
 
+function waitForLocalVideoReady(){
+  return Promise.resolve();
+}
+
 /* -------------------- batching -------------------- */
 async function newBatch(){
   if(fetching) return;


### PR DESCRIPTION
## Summary
- add a waitForLocalVideoReady helper that resolves immediately to prevent boot-time failures

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68fb58fc9f94832581f1ce4af98cf962