### PR TITLE
Improve batch loading stability and feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,9 +132,9 @@
     color:var(--text-100);font:800 20px/1.24 var(--font-display);letter-spacing:0.015em;
   }
 
-  .actions{display:flex;gap:16px;justify-content:space-between;padding:18px;background:linear-gradient(180deg,rgba(10,14,22,0),rgba(22,28,40,0.7));
+  .action-buttons{display:flex;justify-content:space-between;gap:1rem;padding:18px;background:linear-gradient(180deg,rgba(10,14,22,0),rgba(22,28,40,0.7));
     -webkit-backdrop-filter:blur(14px) saturate(160%);backdrop-filter:blur(14px) saturate(160%);}
-  .actions .btn{flex:1;border-radius:var(--radius-lg);padding:16px 18px;font-size:18px;}
+  .action-buttons .btn{flex:1;border-radius:var(--radius-lg);padding:16px 18px;font-size:18px;}
   .btn.ok{color:#03161a;font-weight:800;
     background:linear-gradient(180deg,rgba(255,255,255,0.12),rgba(255,255,255,0.05)),
                linear-gradient(135deg,var(--accent-1),var(--accent-2));
@@ -173,8 +173,21 @@
     .wrap{padding:20px 14px 96px;}
     .dash{grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;}
     .btn.tile{font-size:18px;padding:18px 20px;}
-    .actions{flex-direction:column;}
-    .actions .btn{width:100%;}
+  }
+
+  @media(max-width:320px){
+    .action-buttons{flex-direction:column;}
+    .action-buttons .btn{width:100%;}
+  }
+
+  .toast{
+    position:fixed;bottom:20px;left:50%;transform:translateX(-50%);
+    padding:10px 16px;border-radius:8px;color:white;font-weight:500;
+    opacity:0.95;z-index:9999;transition:opacity 0.3s ease;
+    pointer-events:none;
+    -webkit-backdrop-filter:blur(12px) saturate(160%);
+    backdrop-filter:blur(12px) saturate(160%);
+    box-shadow:0 18px 32px rgba(0,0,0,0.45);
   }
 
   @media(prefers-reduced-motion:reduce){
@@ -191,6 +204,7 @@
     <button class="btn tile small" id="discardBtn">Discard</button>
     <button class="btn tile small" id="localBtn">Local</button>
     <button class="btn tile grad small" id="newBatchBtn">New batch</button>
+    <button class="btn tile small" id="refreshBtn">Refresh</button>
     <button class="btn tile small" id="shuffleBtn">Shuffle feed</button>
     <button class="btn tile small" id="replaceLocalBtn">Replace Video</button>
     <button class="btn tile small" id="addLocalVideosBtn">Add Local Videos</button>
@@ -296,7 +310,7 @@ const LIMIT=100, PAGES=3, CHUNK=30, LIGHT_SHUFFLES=2;
 const AUTOLOAD=true, AUTOLOAD_THRESHOLD_PX=1400, AUTOLOAD_THROTTLE_MS=1400, MAX_APPEND_PER_FRAME=6;
 
 /* -------------------- state -------------------- */
-let pool=[], likes=[], discards=[], currentFeed='home', fetching=false, lastErrors=[], loadLock=false, lastAutoTs=0;
+let pool=[], likes=[], discards=[], currentFeed='home', isFetching=false, lastErrors=[], loadLock=false, lastAutoTs=0;
 const logEl = document.getElementById('log');
 const localVideoInput = document.getElementById('localVideoInput');
 const localFeedEl = document.getElementById('local');
@@ -620,6 +634,36 @@ function saveState(){ try{ localStorage.setItem('likes',JSON.stringify(likes)); 
 function loadState(){ try{ likes=JSON.parse(localStorage.getItem('likes')||'[]'); discards=JSON.parse(localStorage.getItem('discards')||'[]'); }catch{ likes=[]; discards=[]; } }
 loadState();
 
+function showToast(msg, color){
+  const toast=document.createElement('div');
+  toast.textContent=msg;
+  toast.className='toast';
+  toast.style.opacity='0';
+  if(color) toast.style.background=color;
+  document.body.appendChild(toast);
+  requestAnimationFrame(()=>{ toast.style.opacity='0.95'; });
+  setTimeout(()=>{
+    toast.style.opacity='0';
+    setTimeout(()=>toast.remove(),300);
+  },1500);
+}
+
+function persistLike(item){
+  if(!item) return false;
+  const exists=likes.some(it=>it.url===item.url);
+  if(!exists){ likes.push(item); saveState(); }
+  if(currentFeed==='likes'){ paintList('likes', likes); }
+  return !exists;
+}
+
+function persistDiscard(item){
+  if(!item) return false;
+  const exists=discards.some(it=>it.url===item.url);
+  if(!exists){ discards.push(item); saveState(); }
+  if(currentFeed==='discard'){ paintList('discard', discards); }
+  return !exists;
+}
+
 /* viewed persistence */
 const viewed=new Set(JSON.parse(localStorage.getItem('viewed')||'[]'));
 function markViewed(url){
@@ -732,7 +776,7 @@ const ui = {
     setActiveTab(name);
     this.progressVisibility();
   },
-  progressVisibility(){ const visible = currentFeed==='home' && (pool.length>0 || !fetching); el('#progressBtn').style.display = visible ? '' : 'none'; }
+  progressVisibility(){ const visible = currentFeed==='home' && (pool.length>0 || !isFetching); el('#progressBtn').style.display = visible ? '' : 'none'; }
 };
 
 /* =========================================================
@@ -1442,9 +1486,6 @@ function attachSwipe(wrap, item){
     likeStamp.style.transform=`scale(${0.9 + Math.min(0.2, Math.max(0, x/threshold)*0.2)})`;
     noStamp.style.transform=`scale(${0.9 + Math.min(0.2, Math.max(0, -x/threshold)*0.2)})`;
   }
-  function registerLike(i){ if(!likes.some(it=>it.url===i.url)){ likes.push(i); saveState(); } }
-  function registerDiscard(i){ if(!discards.some(it=>it.url===i.url)){ discards.push(i); saveState(); } }
-
   function endSwipe(finalX){
     wrap.classList.remove('swiping');
     const didLike = finalX > threshold, didNo = finalX < -threshold;
@@ -1454,7 +1495,13 @@ function attachSwipe(wrap, item){
       wrap.style.transform=`translateX(${off}px) rotate(${off>0?rotFactor:-rotFactor}deg)`; wrap.style.opacity='0.2';
       setTimeout(()=>{
         const active = currentItem();
-        if(didLike) registerLike(active); else registerDiscard(active);
+        if(didLike){
+          persistLike(active);
+          showToast('Liked!', 'linear-gradient(135deg,var(--accent-1),var(--accent-2))');
+        }else{
+          persistDiscard(active);
+          showToast('Dismissed.', 'linear-gradient(135deg,var(--danger-1),var(--danger-2))');
+        }
         markViewed(active.url);
         wrap.remove();
       },280);
@@ -1512,16 +1559,36 @@ function card(item){
     caption.textContent = captionText; wrap.appendChild(caption);
   }
 
-  const actions=document.createElement('div'); actions.className='actions';
-  actions.innerHTML=`<button class="btn no" data-act="no">Dismiss</button><button class="btn ok" data-act="ok">Like</button>`;
-  actions.addEventListener('click',e=>{
-    const b=e.target.closest('button'); if(!b) return;
-    const targetItem = wrap.__item || item;
-    if(b.dataset.act==='ok'){ if(!likes.some(i=>i.url===targetItem.url)){ likes.push(targetItem); saveState(); } wrap.classList.add('burst'); }
-    else { if(!discards.some(i=>i.url===targetItem.url)){ discards.push(targetItem); saveState(); } wrap.classList.add('fade'); }
-    markViewed(targetItem.url);
+  const actions=document.createElement('div'); actions.className='action-buttons';
+  const dismissBtn=document.createElement('button');
+  dismissBtn.className='btn no dismiss-btn';
+  dismissBtn.type='button';
+  dismissBtn.textContent='Dismiss';
+  const likeBtn=document.createElement('button');
+  likeBtn.className='btn ok like-btn';
+  likeBtn.type='button';
+  likeBtn.textContent='Like';
+
+  dismissBtn.addEventListener('click',()=>{
+    const targetItem=wrap.__item || item;
+    persistDiscard(targetItem);
+    showToast('Dismissed.', 'linear-gradient(135deg,var(--danger-1),var(--danger-2))');
+    markViewed(targetItem?.url);
+    wrap.classList.add('fade');
     setTimeout(()=>wrap.remove(),260);
   });
+
+  likeBtn.addEventListener('click',()=>{
+    const targetItem=wrap.__item || item;
+    persistLike(targetItem);
+    showToast('Liked!', 'linear-gradient(135deg,var(--accent-1),var(--accent-2))');
+    markViewed(targetItem?.url);
+    wrap.classList.add('burst');
+    setTimeout(()=>wrap.remove(),260);
+  });
+
+  actions.appendChild(dismissBtn);
+  actions.appendChild(likeBtn);
   wrap.appendChild(actions);
 
   attachSwipe(wrap, wrap.__item || item);
@@ -1556,10 +1623,10 @@ function waitForLocalVideoReady(){
 }
 
 /* -------------------- batching -------------------- */
-async function newBatch(){
-  if(fetching) return;
+async function loadBatch(){
+  if(isFetching) return;
   await waitForLocalVideoReady();
-  fetching=true; ui.phase('Fetching…'); ui.bar(10); ui.setProgressMode(true);
+  isFetching=true; ui.phase('Fetching…'); ui.bar(10); ui.setProgressMode(true);
   pool.length=0;
   const homeFeed=document.getElementById('home');
   if(homeFeed){
@@ -1567,50 +1634,58 @@ async function newBatch(){
     ensureLocalCardAtTop(homeFeed);
   }
 
-  const subs=[...STARTER_SUBS, ...OPTIONAL_NSFW];
-  const all=[]; let done=0; lastErrors=[];
+  try{
+    const subs=[...STARTER_SUBS, ...OPTIONAL_NSFW];
+    const all=[]; let done=0; lastErrors=[];
 
-  for(const s of subs){
-    const items=await pullSubreddit(s);
-    all.push(...items);
-    done++; ui.bar(10 + (done/subs.length)*80);
-  }
-
-  const seen=new Set(); const deduped=[];
-  for(const it of all){ if(!it?.url) continue; if(seen.has(it.url)) continue; if(viewed.has(it.url)) continue; seen.add(it.url); deduped.push(it); }
-
-  const matched=[], rest=[];
-  for(const it of deduped){
-    const perf=inferPerformer(it);
-    if(titleHasName(it.title) || textMatchesAnyName(perf)) matched.push(it);
-    else rest.push(it);
-  }
-
-  const bucketsTop={}, bucketsRest={};
-  for(const it of matched){ (bucketsTop[it.sub] ||= []).push(it); }
-  for(const it of rest){ (bucketsRest[it.sub] ||= []).push(it); }
-
-  pool=[...interleaveBuckets(bucketsTop), ...interleaveBuckets(bucketsRest)];
-
-  if (pool.length === 0) {
-    log('⚠️ pool empty, showing local only.');
-    ui.setProgressMode(false);
-    if (homeFeed) {
-      homeFeed.innerHTML='';
-      ensureLocalCardAtTop(homeFeed);
+    for(const s of subs){
+      const items=await pullSubreddit(s);
+      all.push(...items);
+      done++; ui.bar(10 + (done/subs.length)*80);
     }
-    fetching=false;
-    ui.progressVisibility();
+
+    const seen=new Set(); const deduped=[];
+    for(const it of all){ if(!it?.url) continue; if(seen.has(it.url)) continue; if(viewed.has(it.url)) continue; seen.add(it.url); deduped.push(it); }
+
+    const matched=[], rest=[];
+    for(const it of deduped){
+      const perf=inferPerformer(it);
+      if(titleHasName(it.title) || textMatchesAnyName(perf)) matched.push(it);
+      else rest.push(it);
+    }
+
+    const bucketsTop={}, bucketsRest={};
+    for(const it of matched){ (bucketsTop[it.sub] ||= []).push(it); }
+    for(const it of rest){ (bucketsRest[it.sub] ||= []).push(it); }
+
+    pool=[...interleaveBuckets(bucketsTop), ...interleaveBuckets(bucketsRest)];
+
+    if (pool.length === 0) {
+      log('⚠️ pool empty, showing local only.');
+      ui.setProgressMode(false);
+      if (homeFeed) {
+        homeFeed.innerHTML='';
+        ensureLocalCardAtTop(homeFeed);
+      }
+      document.dispatchEvent(new Event('videosBuilt'));
+      return;
+    }
+
+    ui.bar(100); ui.phase('Ready'); ui.setProgressMode(false);
+    await renderChunk('home', Math.min(CHUNK, pool.length));
+    if (homeFeed) ensureLocalCardAtTop(homeFeed);
+
     document.dispatchEvent(new Event('videosBuilt'));
-    return;
+  }catch(err){
+    const msg = `loadBatch failed: ${truncateLog(err && err.message ? err.message : err, 180)}`;
+    lastErrors.push(msg);
+    log(`⚠️ ${msg}`);
+    ui.setProgressMode(false);
+    document.dispatchEvent(new Event('videosBuilt'));
+  }finally{
+    isFetching=false;
+    ui.progressVisibility();
   }
-
-  ui.bar(100); ui.phase('Ready'); ui.setProgressMode(false);
-  await renderChunk('home', Math.min(CHUNK, pool.length));
-  if (homeFeed) ensureLocalCardAtTop(homeFeed);
-  fetching=false;
-
-  document.dispatchEvent(new Event('videosBuilt'));
 }
 
 /* -------------------- shuffle/subs/troubleshoot -------------------- */
@@ -1695,7 +1770,11 @@ window.addEventListener('beforeunload', () => {
   clearLocalFeedObjectUrls();
 });
 
-document.getElementById('newBatchBtn').addEventListener('click', newBatch);
+document.getElementById('newBatchBtn').addEventListener('click', loadBatch);
+const refreshBtn = document.getElementById('refreshBtn');
+if(refreshBtn){
+  refreshBtn.addEventListener('click', ()=>{ loadBatch(); });
+}
 document.getElementById('shuffleBtn').addEventListener('click', shuffleVisibleAndPool);
 const replaceLocalBtn = document.getElementById('replaceLocalBtn');
 if (replaceLocalBtn && localVideoInput) {
@@ -1731,7 +1810,7 @@ document.getElementById('connectBtn').addEventListener('click', beginOAuth);
 document.getElementById('subsSelectAll').addEventListener('click', ()=>{ document.querySelectorAll('#subsGrid input[type="checkbox"]')?.forEach(c=>c.checked=true); });
 document.getElementById('subsClearAll').addEventListener('click', ()=>{ document.querySelectorAll('#subsGrid input[type="checkbox"]')?.forEach(c=>c.checked=false); });
 document.getElementById('subsBack').addEventListener('click', ()=> ui.showPage('home'));
-document.getElementById('subsSave').addEventListener('click', async ()=>{ saveSubsFromUI(); await newBatch(); ui.showPage('home'); });
+document.getElementById('subsSave').addEventListener('click', async ()=>{ saveSubsFromUI(); await loadBatch(); ui.showPage('home'); });
 
 if (clearLocalBtn) {
   clearLocalBtn.addEventListener('click', () => {
@@ -1773,16 +1852,23 @@ if (pageTabsEl) {
 function paintList(where, arr){ const host=document.getElementById(where); host.innerHTML=''; arr.forEach(it=>host.appendChild(card(it))); }
 
 /* -------------------- autoload on scroll -------------------- */
-function onScrollAuto(){
+async function onScrollAuto(){
   if(!AUTOLOAD || currentFeed!=='home') return;
-  if(loadLock) return;
   const doc=document.documentElement;
   const scrollTop=getScrollY();
   const nearBottom=(doc.scrollHeight - (scrollTop + window.innerHeight)) < AUTOLOAD_THRESHOLD_PX;
   const now=performance.now();
-  if(nearBottom && (now - lastAutoTs) > AUTOLOAD_THROTTLE_MS){ lastAutoTs=now; renderChunk('home'); }
+  if(nearBottom && !loadLock && pool.length>0 && (now - lastAutoTs) > AUTOLOAD_THROTTLE_MS){
+    lastAutoTs=now;
+    renderChunk('home');
+  }
+
+  if(window.innerHeight + window.scrollY >= document.body.offsetHeight - 200){
+    if(pool.length>0 || loadLock || isFetching) return;
+    await loadBatch();
+  }
 }
-window.addEventListener('scroll', onScrollAuto, {passive:true});
+window.addEventListener('scroll', () => { onScrollAuto().catch(err => console.error(err)); }, {passive:true});
 
 /* -------------------- OAuth helpers (implicit) -------------------- */
 function rand(n=12){ return Array.from(crypto.getRandomValues(new Uint8Array(n))).map(v=>(v%36).toString(36)).join(''); }
@@ -1821,7 +1907,7 @@ bootstrapLocalFeed();
 bootstrapLocalVideo();
 (async ()=>{
   await waitForLocalVideoReady();
-  await newBatch();
+  await loadBatch();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- align the dismiss/like action buttons with the requested flex layout, add a refresh shortcut, and style toast notifications for lightweight feedback
- introduce toast helpers and shared like/dismiss persistence so button clicks and swipe gestures update saved lists while confirming actions
- harden batch loading with an isFetching gate, scroll-triggered refresh, and reuse of the new loader across manual refresh paths

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fba053b8b08325b8595845dc78dde3