### PR TITLE
Add environment variable loader for OpenAI API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Local environment variables
+.env
+
+# Node modules
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "budget-app-2",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+
+const loadedEnvPaths = new Set();
+
+function parseLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return null;
+  }
+
+  const equalsIndex = trimmed.indexOf('=');
+  if (equalsIndex === -1) {
+    return null;
+  }
+
+  const key = trimmed.slice(0, equalsIndex).trim();
+  let value = trimmed.slice(equalsIndex + 1).trim();
+
+  if (!key) {
+    return null;
+  }
+
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+
+  return [key, value];
+}
+
+function loadEnv(options = {}) {
+  const envPath = options.envPath
+    ? path.resolve(options.envPath)
+    : path.resolve(process.cwd(), '.env');
+
+  if (loadedEnvPaths.has(envPath)) {
+    return;
+  }
+
+  if (!fs.existsSync(envPath)) {
+    loadedEnvPaths.add(envPath);
+    return;
+  }
+
+  const content = fs.readFileSync(envPath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  for (const line of lines) {
+    const entry = parseLine(line);
+    if (!entry) {
+      continue;
+    }
+
+    const [key, value] = entry;
+    if (Object.prototype.hasOwnProperty.call(process.env, key)) {
+      continue;
+    }
+    process.env[key] = value;
+  }
+
+  loadedEnvPaths.add(envPath);
+}
+
+function getOpenAiApiKey(options = {}) {
+  loadEnv(options);
+  const rawValue = process.env.OPENAI_API_KEY;
+  if (!rawValue) {
+    throw new Error('OPENAI_API_KEY is not configured. Set it in your environment or in a .env file.');
+  }
+  return rawValue.trim();
+}
+
+module.exports = {
+  loadEnv,
+  getOpenAiApiKey,
+};

--- a/test/env.test.js
+++ b/test/env.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
+const { loadEnv, getOpenAiApiKey } = require('../src/config/env');
+
+test('loadEnv reads values from a .env file without overwriting existing variables', async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'budget-env-'));
+  const envPath = path.join(tempDir, '.env');
+  await fs.writeFile(envPath, "EXISTING=value\nOPENAI_API_KEY=temp-key\n");
+
+  process.env.EXISTING = 'already-set';
+  delete process.env.OPENAI_API_KEY;
+
+  loadEnv({ envPath });
+
+  assert.equal(process.env.EXISTING, 'already-set');
+  assert.equal(process.env.OPENAI_API_KEY, 'temp-key');
+});
+
+test('getOpenAiApiKey returns trimmed value when available in environment', async (t) => {
+  process.env.OPENAI_API_KEY = '   padded-key   ';
+  const key = getOpenAiApiKey();
+  assert.equal(key, 'padded-key');
+});
+
+test('getOpenAiApiKey loads from .env file and throws if missing', async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'budget-env-missing-'));
+  const envPath = path.join(tempDir, '.env');
+  await fs.writeFile(envPath, '# comment only\n');
+
+  delete process.env.OPENAI_API_KEY;
+
+  assert.throws(() => getOpenAiApiKey({ envPath }), /OPENAI_API_KEY is not configured/);
+});


### PR DESCRIPTION
## Summary
- add a gitignore entry to keep the local .env file out of version control
- add a lightweight environment loader that reads the OpenAI API key from .env without exposing it
- configure a node test suite that validates the loader and keeps the key handling secure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbdd9112b48325bf454a92dc66bc37