### PR TITLE
Add rate-limited OpenAI connection test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Local environment variables
 .env
+.last-openai-check
 
 # Node modules
-node_modules/
+/node_modules/*
+!/node_modules/dotenv/
+!/node_modules/dotenv/**
+!/node_modules/node-fetch/
+!/node_modules/node-fetch/**

--- a/node_modules/dotenv/index.js
+++ b/node_modules/dotenv/index.js
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+
+function parse(content) {
+  const result = {};
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+    const equalsIndex = trimmed.indexOf('=');
+    if (equalsIndex === -1) {
+      continue;
+    }
+    const key = trimmed.slice(0, equalsIndex).trim();
+    let value = trimmed.slice(equalsIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!key) {
+      continue;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+export function config(options = {}) {
+  const envPath = options.path
+    ? path.resolve(options.path)
+    : path.resolve(process.cwd(), '.env');
+
+  if (!fs.existsSync(envPath)) {
+    return { parsed: {} };
+  }
+
+  const content = fs.readFileSync(envPath, 'utf8');
+  const parsed = parse(content);
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof process.env[key] === 'undefined') {
+      process.env[key] = value;
+    }
+  }
+
+  return { parsed };
+}
+
+export default { config };

--- a/node_modules/dotenv/package.json
+++ b/node_modules/dotenv/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dotenv",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/node_modules/node-fetch/index.js
+++ b/node_modules/node-fetch/index.js
@@ -1,0 +1,9 @@
+const globalFetch = globalThis.fetch;
+
+if (typeof globalFetch !== 'function') {
+  throw new Error('Global fetch API is not available in this environment.');
+}
+
+export default function fetch(input, init) {
+  return globalFetch(input, init);
+}

--- a/node_modules/node-fetch/package.json
+++ b/node_modules/node-fetch/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "node-fetch",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "budget-app-2",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "node --test"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
 const loadedEnvPaths = new Set();
 
@@ -31,7 +31,7 @@ function parseLine(line) {
   return [key, value];
 }
 
-function loadEnv(options = {}) {
+export function loadEnv(options = {}) {
   const envPath = options.envPath
     ? path.resolve(options.envPath)
     : path.resolve(process.cwd(), '.env');
@@ -64,7 +64,7 @@ function loadEnv(options = {}) {
   loadedEnvPaths.add(envPath);
 }
 
-function getOpenAiApiKey(options = {}) {
+export function getOpenAiApiKey(options = {}) {
   loadEnv(options);
   const rawValue = process.env.OPENAI_API_KEY;
   if (!rawValue) {
@@ -73,7 +73,7 @@ function getOpenAiApiKey(options = {}) {
   return rawValue.trim();
 }
 
-module.exports = {
+export default {
   loadEnv,
   getOpenAiApiKey,
 };

--- a/test/env.test.js
+++ b/test/env.test.js
@@ -1,10 +1,10 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
-const fs = require('fs/promises');
-const path = require('path');
-const os = require('os');
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
 
-const { loadEnv, getOpenAiApiKey } = require('../src/config/env');
+import { loadEnv, getOpenAiApiKey } from '../src/config/env.js';
 
 test('loadEnv reads values from a .env file without overwriting existing variables', async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'budget-env-'));

--- a/test/openai-connection.test.js
+++ b/test/openai-connection.test.js
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import dotenv from 'dotenv';
+import assert from 'assert';
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+
+dotenv.config();
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY;
+const RATE_LIMIT_FILE = path.resolve('.last-openai-check');
+
+function canRunTest() {
+  try {
+    const lastRun = fs.readFileSync(RATE_LIMIT_FILE, 'utf8');
+    const last = new Date(lastRun);
+    const now = new Date();
+    const hours = (now - last) / (1000 * 60 * 60);
+    return hours >= 24;
+  } catch {
+    return true;
+  }
+}
+
+function updateLastRun() {
+  fs.writeFileSync(RATE_LIMIT_FILE, new Date().toISOString());
+}
+
+describe('OpenAI API Connection', () => {
+  it('should connect successfully using the environment key (rate-limited)', async () => {
+    if (!canRunTest()) {
+      console.log('⏳ Skipping OpenAI connection test (last run <24h ago).');
+      return;
+    }
+
+    assert.ok(OPENAI_KEY, 'Missing OPENAI_API_KEY in .env');
+
+    const response = await fetch('https://api.openai.com/v1/models', {
+      headers: {
+        Authorization: `Bearer ${OPENAI_KEY}`,
+      },
+    });
+
+    assert.strictEqual(response.status, 200, 'OpenAI API did not return 200 OK');
+
+    const data = await response.json();
+    assert.ok(Array.isArray(data.data), 'Response format is unexpected');
+    console.log(`✅ Connection OK. Models available: ${data.data.length}`);
+
+    updateLastRun();
+  });
+});


### PR DESCRIPTION
## Summary
- convert the configuration utilities and existing tests to native ES modules
- vendor lightweight dotenv and node-fetch shims so the OpenAI connectivity check can run without external packages
- add a rate-limited OpenAI API connection test that verifies the configured key loads correctly

## Testing
- npm test *(fails: Missing OPENAI_API_KEY in .env)*

------
https://chatgpt.com/codex/tasks/task_e_68fbdfe293b083258afd73273f643ab9