### PR TITLE
Fix zoom overlay to detach from transformed parents and prevent background scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1540,6 +1540,8 @@ function card(item){
 
 let zoomOverlayEl = null;
 let zoomOverlayMediaEl = null;
+let previousBodyOverflow = '';
+let previousBodyTransform = '';
 
 function ensureZoomOverlay(){
   if (!zoomOverlayEl) {
@@ -1547,6 +1549,24 @@ function ensureZoomOverlay(){
     zoomOverlayEl.className = 'zoom-overlay';
     zoomOverlayEl.setAttribute('aria-hidden', 'true');
     zoomOverlayEl.addEventListener('click', closeZoomOverlay);
+    zoomOverlayEl.style.position = 'fixed';
+    zoomOverlayEl.style.top = '0';
+    zoomOverlayEl.style.right = '0';
+    zoomOverlayEl.style.bottom = '0';
+    zoomOverlayEl.style.left = '0';
+    zoomOverlayEl.style.display = 'flex';
+    zoomOverlayEl.style.alignItems = 'center';
+    zoomOverlayEl.style.justifyContent = 'center';
+    zoomOverlayEl.style.background = 'rgba(0,0,0,0.85)';
+    zoomOverlayEl.style.backfaceVisibility = 'hidden';
+    zoomOverlayEl.style.willChange = 'opacity';
+    zoomOverlayEl.style.isolation = 'isolate';
+    zoomOverlayEl.style.zIndex = '9999';
+    zoomOverlayEl.style.cursor = 'zoom-out';
+    zoomOverlayEl.style.setProperty('transform', 'none', 'important');
+    document.body.appendChild(zoomOverlayEl);
+  }
+  if (zoomOverlayEl.parentElement !== document.body) {
     document.body.appendChild(zoomOverlayEl);
   }
   return zoomOverlayEl;
@@ -1577,10 +1597,21 @@ function openZoomOverlay(sourceEl){
     clone.decoding = 'async';
   }
 
+  clone.style.position = 'fixed';
+  clone.style.top = '0';
+  clone.style.right = '0';
+  clone.style.bottom = '0';
+  clone.style.left = '0';
+  clone.style.margin = 'auto';
+  clone.style.setProperty('transform', 'none', 'important');
+
   overlay.innerHTML = '';
   overlay.appendChild(clone);
   overlay.setAttribute('aria-hidden', 'false');
+  previousBodyOverflow = document.body.style.overflow;
+  previousBodyTransform = document.body.style.transform;
   document.body.style.overflow = 'hidden';
+  document.body.style.transform = 'none';
   requestAnimationFrame(()=>{
     overlay.classList.add('is-active');
     if (clone instanceof HTMLVideoElement) {
@@ -1597,7 +1628,10 @@ function closeZoomOverlay(){
     overlay.innerHTML = '';
     overlay.setAttribute('aria-hidden', 'true');
     zoomOverlayMediaEl = null;
-    document.body.style.overflow = '';
+    document.body.style.overflow = previousBodyOverflow;
+    document.body.style.transform = previousBodyTransform;
+    previousBodyOverflow = '';
+    previousBodyTransform = '';
     return;
   }
 
@@ -1607,12 +1641,15 @@ function closeZoomOverlay(){
 
   overlay.classList.remove('is-active');
   overlay.setAttribute('aria-hidden', 'true');
-  document.body.style.overflow = '';
+  document.body.style.overflow = previousBodyOverflow;
+  document.body.style.transform = previousBodyTransform;
 
   const cleanup = (event) => {
     if (event && event.target !== overlay) return;
     overlay.innerHTML = '';
     zoomOverlayMediaEl = null;
+    previousBodyOverflow = '';
+    previousBodyTransform = '';
   };
 
   overlay.addEventListener('transitionend', function handle(e){


### PR DESCRIPTION
## Summary
- create the zoom overlay directly on document.body with fixed positioning and isolation styles so it no longer inherits parent transforms
- pin cloned media with inline fixed positioning, disable inherited transforms, and freeze body scrolling/transform while the overlay is active
- restore the original body styles once the overlay closes to keep the page layout untouched

## Testing
- npm test *(fails: requires OPENAI_API_KEY in .env)*

------
https://chatgpt.com/codex/tasks/task_e_68fd1a9e484c8325ab0f55d5199c812a