### PR TITLE
Fine-tune autoload scroll behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,7 +360,7 @@ let OPTIONAL_NSFW = saved.nsfw     || [...DEFAULT_OPTIONAL_NSFW];
 
 /* -------------------- tunables -------------------- */
 const LIMIT=100, PAGES=3, CHUNK=30, LIGHT_SHUFFLES=2;
-const AUTOLOAD=true, AUTOLOAD_THRESHOLD_PX=1400, AUTOLOAD_THROTTLE_MS=1400, MAX_APPEND_PER_FRAME=6;
+const AUTOLOAD=true, AUTOLOAD_THRESHOLD_PX=1000, AUTOLOAD_THROTTLE_MS=800, MAX_APPEND_PER_FRAME=6;
 
 /* -------------------- state -------------------- */
 let pool=[], likes=[], discards=[], currentFeed='home', isFetching=false, lastErrors=[], loadLock=false, lastAutoTs=0;
@@ -1902,15 +1902,19 @@ async function onScrollAuto(){
   if(!AUTOLOAD || currentFeed!=='home') return;
   const doc=document.documentElement;
   const scrollTop=getScrollY();
-  const nearBottom=(doc.scrollHeight - (scrollTop + window.innerHeight)) < AUTOLOAD_THRESHOLD_PX;
+  const remaining=doc.scrollHeight - (scrollTop + window.innerHeight);
+  const nearBottom=remaining < AUTOLOAD_THRESHOLD_PX;
+  const atBottom=remaining <= 0;
   const now=performance.now();
   if(nearBottom && !loadLock && pool.length>0 && (now - lastAutoTs) > AUTOLOAD_THROTTLE_MS){
     lastAutoTs=now;
+    dbg('autoload: loading next chunk');
     renderChunk('home');
   }
 
-  if(window.innerHeight + window.scrollY >= document.body.offsetHeight - 200){
-    if(pool.length>0 || loadLock || isFetching) return;
+  if(atBottom){
+    if (loadLock || isFetching) return;
+    if(pool.length>0) return;
     await loadBatch();
   }
 }


### PR DESCRIPTION
## Summary
- lower the autoload scroll threshold and throttle so chunks render sooner while scrolling
- add debug logging for autoload chunk rendering and guard batch loads until the feed pool is empty

## Testing
- `npm test` *(fails: missing OPENAI_API_KEY expected by OpenAI API Connection test)*

------
https://chatgpt.com/codex/tasks/task_e_68fd61840f748325b67261cb4306a821